### PR TITLE
fixed retrieve method does not fire then because request url has moved(301)

### DIFF
--- a/lib/Method.basic.js
+++ b/lib/Method.basic.js
@@ -15,7 +15,7 @@ module.exports = {
 
   retrieve: Method({
     method: 'GET',
-    path: '/{id}',
+    path: '/{id}/',
     urlParams: ['id']
   }),
 


### PR DESCRIPTION
this is quick fix.
should follow redirects for fixing root cause.
(IMHO, use requestjs instead of http/https module in Resouce.js:makeRequest)