### PR TITLE
Add "s" to Parcels API

### DIFF
--- a/lib/shippo.js
+++ b/lib/shippo.js
@@ -13,7 +13,7 @@ Shippo.USER_AGENT = 'shippo-node '+Shippo.PACKAGE_VERSION;
 Shippo.resources = {
   Addresses: require('./resources/Addresses'),
   Shipments: require('./resources/Shipments'),
-  Parcel: require('./resources/Parcels'),
+  Parcels: require('./resources/Parcels'),
   Transactions: require('./resources/Transactions'),
   CustomsItems: require('./resources/CustomsItems'),
   CustomsDeclarations: require('./resources/CustomsDeclarations')


### PR DESCRIPTION
Missing "s" on Parcels API.
`shippo.parcels.list().then(...)` is looks correct but now Parcels API is `shippo.parcel.list().then(...)`
