### PR TITLE
Fixed wrong content-length setting for non-ascii chars

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -158,7 +158,7 @@ Resource.prototype = {
 
   _request: function(method, path, data, auth, callback) {
 
-    var requestData = JSON.stringify(data || {});
+    var requestData = new Buffer(JSON.stringify(data || {}));
     var self = this;
 
     var apiVersion = this._shippo.get('version');


### PR DESCRIPTION
In the current version of the node wrapper, the _request method in the /lib/Resource.js sets "Content-length" character length instead of byte length of the 'requestData'. For a string that includes non-ascii characters - which require more than one byte to be represented - this ends up in setting the a wrong "Content-length
