### PR TITLE
feat: Add support to allow alternate WebAPI Fetch implementation

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -161,6 +161,7 @@ Resource.prototype = {
             );
         }
     },
+
     _get_headers: function(requestData) {
         var apiVersion = this._shippo.get('version');
         var headers = {
@@ -178,8 +179,42 @@ Resource.prototype = {
         return headers
 
     },
-    _request: function(method, path, data, auth, callback) {
 
+    _formFetchResponse(response) {
+        return new Promise(resolve => {
+          response.text().then(body => {
+            let json = '{}'
+      
+            if (body !== '') {
+              json = JSON.parse(body)
+            }
+      
+            if (!response.ok) {
+              json = { errors: [{ status: response.status }] }
+            }
+      
+            resolve({
+              status: response.status,
+              ok: response.ok,
+              json
+            })
+          })
+        })
+    },
+
+    _handleFetchResponse(response) {
+        var self = this;
+
+        return self._formFetchResponse(response).then(responseObj => {
+            if(responseObj.ok) {
+                return responseObj.json;
+            } else {
+                throw new Error(responseObj.json);
+            }
+        }).catch(error => reject(error));
+    },
+    
+    _request: function(method, path, data, auth, callback) {
         var requestData = new Buffer(JSON.stringify(data || {}));
         var self = this;
         var queryParams = querystring.stringify(data);
@@ -188,8 +223,33 @@ Resource.prototype = {
             path = [path, queryParams].join('?');
         }
 
-        var headers = self._get_headers(requestData)
-        makeRequest();
+        const headers = self._get_headers(requestData);
+        const Fetch = self._shippo.get('Fetch');
+        if(Fetch && typeof(Fetch) === 'function') {
+            var uri = (self._shippo.get('endpoint'))?self._shippo.get('endpoint'):`${self._shippo.get('protocol') == 'http' ? 'http' : 'https'}://${self._shippo.get('host')}:${self._shippo.get('port')||80}${path}`;
+
+            Fetch.bind(self)(new Request(uri, {
+                    method: method, 
+                    body: JSON.stringify(data),
+                    headers: new Headers(headers)
+                }))
+                .then(fetchResponse => self._handleFetchResponse(fetchResponse))
+                .then(response => {
+                    return callback.call(self, null, response);
+                })
+                .catch(error => {
+                    return callback.call(
+                        self,
+                        new Error.ShippoConnectionError({
+                            message: 'An error occurred with our connection to Shippo',
+                            detail: error
+                        }),
+                        null
+                    );
+                });
+        } else {
+            makeRequest();
+        }
 
         function makeRequest() {
 
@@ -211,9 +271,7 @@ Resource.prototype = {
 
             req.write(requestData);
             req.end();
-
         }
-
     }
 
 };

--- a/lib/shippo.js
+++ b/lib/shippo.js
@@ -27,10 +27,9 @@ Shippo.resources = {
 
 Shippo.Resource = require('./Resource');
 
-function Shippo(token) {
-
+function Shippo(token, params = null) {
   if (!(this instanceof Shippo)) {
-    return new Shippo(token);
+    return new Shippo(token, params);
   }
 
 
@@ -45,6 +44,14 @@ function Shippo(token) {
 
   if(typeof(token) !== 'undefined') {
     this.setToken(token);
+  }
+
+  if(params && Array.isArray(params)) {
+      Object.values(params).map((param) => {
+        Object.entries(param).map(([key, value]) => {
+          this.set(key, value);
+        });
+    });
   }
 
   this._init();

--- a/lib/shippo.js
+++ b/lib/shippo.js
@@ -4,7 +4,12 @@ Shippo.DEFAULT_HOST = 'api.goshippo.com';
 Shippo.DEFAULT_PROTOCOL = 'https';
 Shippo.DEFAULT_PORT = '443';
 Shippo.DEFAULT_BASE_PATH = '/';
-Shippo.DEFAULT_TIMEOUT = require('http').createServer().timeout;
+Shippo.DEFAULT_TIMEOUT = 2000;
+try{
+  // http is not in package.json so this fails unless installed
+  Shippo.DEFAULT_TIMEOUT = require('http').createServer().timeout;
+}catch(error){}
+
 //require('../package.json').version;
 Shippo.PACKAGE_VERSION = '0.0.2';
 


### PR DESCRIPTION
## Type

* ### Feature
  Implements a new feature

## Description
_A brief description of the goals of the pull request._
* Allows `Fetch` to be passed into `Shippo` configuration for custom implementation that matches WebAPI spec to be used for calls to API. This allows alternate/compliant implementations of the Fetch (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) spec to be used.

```
    var shippo = require('shippo')('<YOUR_PRIVATE_KEY>', [
      { Fetch: myCustomWebAPIfetch }
    ]);
```

## Dependencies
_Other PRs or builds that this PR depends on._
* N/A

## Issues

*A list of issues closed by this PR.*

* N/A

## Notes

* Ex. - a scenario where you want to proxy the request to avoid exposing `<YOUR_PRIVATE_KEY>` in any requests.
