### PR TITLE
hardcode API timeout value to 30s

### DIFF
--- a/lib/shippo.js
+++ b/lib/shippo.js
@@ -4,8 +4,7 @@ Shippo.DEFAULT_HOST = 'api.goshippo.com';
 Shippo.DEFAULT_PROTOCOL = 'https';
 Shippo.DEFAULT_PORT = '443';
 Shippo.DEFAULT_BASE_PATH = '/';
-Shippo.DEFAULT_TIMEOUT = require('http').createServer().timeout;
-//require('../package.json').version;
+Shippo.DEFAULT_TIMEOUT = 30000; // 30 seconds; override with setTimeout on Shippo instance
 Shippo.PACKAGE_VERSION = '0.0.2';
 
 Shippo.USER_AGENT = 'Shippo/v1 NodeBindings/'+Shippo.PACKAGE_VERSION;


### PR DESCRIPTION
instead of using node http module's default, which changed from 120s to 0 (no timeout) in node v13

resolves #10, #55 