### PR TITLE
add support for OAuth tokens

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -165,7 +165,7 @@ Resource.prototype = {
         var apiVersion = this._shippo.get('version');
         var headers = {
             // Use specified auth token or use default from this shippo instance:
-            'Authorization': 'ShippoToken ' + this._shippo.get('token'),
+            'Authorization': this._shippo.get('authScheme') + ' ' + this._shippo.get('token'),
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'Content-Length': requestData.length,

--- a/lib/shippo.js
+++ b/lib/shippo.js
@@ -1,8 +1,12 @@
 'use strict';
 
+Shippo.AUTH_SCHEME_SHIPPO = 'ShippoToken'
+Shippo.AUTH_SCHEME_OAUTH = 'Bearer'
+
 Shippo.DEFAULT_HOST = 'api.goshippo.com';
 Shippo.DEFAULT_PROTOCOL = 'https';
 Shippo.DEFAULT_PORT = '443';
+Shippo.DEFAULT_AUTH_SCHEME = Shippo.AUTH_SCHEME_SHIPPO;
 Shippo.DEFAULT_BASE_PATH = '/';
 Shippo.DEFAULT_TIMEOUT = 30000; // 30 seconds; override with setTimeout on Shippo instance
 Shippo.PACKAGE_VERSION = '0.0.2';
@@ -25,6 +29,7 @@ Shippo.resources = {
   Order: require('./resources/Order')
 };
 
+Shippo.Error = require('./Error');
 Shippo.Resource = require('./Resource');
 
 function Shippo(token) {
@@ -38,6 +43,7 @@ function Shippo(token) {
     host: Shippo.DEFAULT_HOST,
     port: Shippo.DEFAULT_PORT,
     protocol: Shippo.DEFAULT_PROTOCOL,
+    authScheme: Shippo.DEFAULT_AUTH_SCHEME,
     basePath: Shippo.DEFAULT_BASE_PATH,
     timeout: Shippo.DEFAULT_TIMEOUT,
     dev: false
@@ -51,10 +57,15 @@ function Shippo(token) {
 }
 
 Shippo.prototype = {
+
+  setAuthScheme: function(auth) {
+    this.set('authScheme', auth);
+  },
+
   setHost: function(host, port, protocol) {
     this.set('host', host);
     if (port) this.set('port', port);
-    if (protocol) this.set('protcol', protocol);
+    if (protocol) this.set('protocol', protocol);
   },
 
   setProtocol: function(protocol) {
@@ -65,8 +76,26 @@ Shippo.prototype = {
     this.set('port', port);
   },
 
+  // token can be provided as a string, or as an object with either a 'shippoToken' or 'oauthToken' attribute
   setToken: function(token) {
-    this.set('token', token);
+    var shippoToken = (typeof token === 'object') ? token.shippoToken : token;
+    var oauthToken = (typeof token === 'object') ? token.oauthToken : undefined;
+
+    if (shippoToken && oauthToken) {
+      throw new Shippo.Error.ShippoError({
+        message: 'Ambiguous authentication credentials',
+        detail: "Please provide either 'shippoToken' or 'oauthToken', not both"
+      });
+    }
+
+    if (oauthToken) {
+      this.set('authScheme', Shippo.AUTH_SCHEME_OAUTH);
+      this.set('token', oauthToken);
+    } else {
+      this.set('authScheme', Shippo.AUTH_SCHEME_SHIPPO);
+      this.set('token', shippoToken);  
+    }
+
   },
 
   setTimeout: function(timeout) {

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -1,16 +1,66 @@
 'use strict';
 
-var shippo = require('./testUtils').getSpyableShippo();
+var getSpyableShippo = require('./testUtils').getSpyableShippo;
 var expect = require('chai').expect;
 
 describe('Resourcetest', function() {
 
+    var shippo;
+
     describe('apiVersionSet', function() {
+
+        before(function() {
+            shippo = getSpyableShippo();
+        });
 
         it('tests that the version header is properly set', function() {
             shippo.set('version', 'sample_version')
             expect(shippo.address._get_headers('mock_request')['Shippo-API-Version']).to.equal('sample_version');
         });
+
+    });
+
+    describe('authorization tokens', function() {
+
+        describe('on init', function() {
+
+            it('correctly uses a shippoToken by default', function () {
+                shippo = getSpyableShippo('mockShippoToken');
+                expect(shippo.address._get_headers('mock_request')['Authorization']).to.equal('ShippoToken mockShippoToken');
+            });
+
+            it('correctly uses an explicit shippoToken', function () {
+                shippo = getSpyableShippo({shippoToken: 'anotherMockShippoToken'});
+                expect(shippo.address._get_headers('mock_request')['Authorization']).to.equal('ShippoToken anotherMockShippoToken');
+            })
+
+            it('correctly uses an explicit oauthToken', function () {
+                shippo = getSpyableShippo({oauthToken: 'mockOauthToken'});
+                expect(shippo.address._get_headers('mock_request')['Authorization']).to.equal('Bearer mockOauthToken');
+            })
+
+            it('throws an error if both tokens are provided', function () {
+                expect(function () {
+                    getSpyableShippo({shippoToken: 'mockToken1', oauthToken: 'mockToken2'});
+                }).to.throw('Ambiguous authentication credentials');
+            })
+
+        });
+
+        describe('setToken method', function() {
+
+            it('correctly sets shippoToken', function() {
+                shippo = getSpyableShippo({ oauthToken: 'mockOauthToken' });
+                shippo.setToken({ shippoToken: 'mockShippoToken' });
+                expect(shippo.address._get_headers('mock_request')['Authorization']).to.equal('ShippoToken mockShippoToken');
+            })
+
+            it('correctly sets oauthToken', function() {
+                shippo = getSpyableShippo({shippoToken: 'mockShippoToken'});
+                shippo.setToken({ oauthToken: 'mockOauthToken' });
+                expect(shippo.address._get_headers('mock_request')['Authorization']).to.equal('Bearer mockOauthToken');
+            })
+        })
 
     });
 

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -12,12 +12,12 @@ var utils = module.exports = {
     return process.env.SHIPPO_TEST_API_KEY || ('unittest');
   },
 
-  getSpyableShippo: function() {
+  getSpyableShippo: function(token) {
     // Provide a testable shippo instance
     // That is, with mock-requests built in and hookable
 
     var Shippo = require('../lib/shippo');
-    var shippoInstance = Shippo('fakeAuthToken');
+    var shippoInstance = Shippo(token || 'fakeAuthToken');
 
     shippoInstance.REQUESTS = [];
 


### PR DESCRIPTION
Shippo constructor will now optionally an object with either a 'shippoToken' or an 'oauthToken' attribute, and will use the corresponding Authorization method on requests

resolves #53 