### PR TITLE
(feature) Enable more visibility into all response errors

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -108,23 +108,22 @@ Resource.prototype = {
             res.on('end', function() {
                 var err;
 
-                try {
-                    response = JSON.parse(response);
-                } catch (e) {
-                    return callback.call(
-                        self,
-                        new Error.ShippoAPIError({
-                            message: 'Invalid JSON received from the Shippo API'
-                        }),
-                        null
-                    );
-                }
-
                 var errData = {
                     detail: response,
                     path: req.path,
                     statusCode: res.statusCode
                 };
+
+                try {
+                    response = JSON.parse(response);
+                } catch (e) {
+                    errData.message = "Invalid JSON received from the Shippo API";
+                    return callback.call(
+                        self,
+                        new Error.ShippoAPIError(errData),
+                        null
+                    );
+                }
 
                 if (res.statusCode === 401) {
                     errData.message = "Invalid credentials";

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -64,7 +64,7 @@ describe('Resourcetest', function() {
 
     });
 
-    describe.only('_responseHandler', function() {
+    describe('_responseHandler', function() {
 
         describe('when a json parse error is caught', function() {
 

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -64,4 +64,44 @@ describe('Resourcetest', function() {
 
     });
 
+    describe.only('_responseHandler', function() {
+
+        describe('when a json parse error is caught', function() {
+
+            it('should return a generic error with full error data', function() {
+                var expectedErrorData = {
+                    detail: '',
+                    path: '/testing',
+                    statusCode: 429,
+                    message: 'Invalid JSON received from the Shippo API',
+                    type: 'ShippoAPIError'
+                };
+
+                var fakeRequest = {
+                    path: '/testing',
+                };
+
+                shippo = getSpyableShippo({ oauthToken: 'mockOauthToken' });
+                const responseCallback = shippo.address._responseHandler(fakeRequest, function(error, _) {
+                    for (var k in Object.keys(error)) {
+                        expect(expectedErrorData[k]).to.eql(error[k]);
+                    }
+                });
+
+                responseCallback({
+                    statusCode: 429,
+                    setEncoding: function() {},
+                    on: function (eventName, eventCallback) {
+                        if (eventName === 'end') {
+                            eventCallback();
+                        }
+                    },
+                });
+
+            });
+
+        });
+
+    });
+
 });


### PR DESCRIPTION
## Context

There are certain errors that Shippo will return that result in a `JSON parse` error.  When this happens, it will return a generic `ShippoAPIError` without any response data to help understand what actually happened.

This is most evident when hitting the Shippo API rate limit, which will trigger a 429. In this case, the node-client will throw the generic error, without that status code or anything to truly know that is what happened.

## Analysis

The error already supports adding in additional context, such as status code, we simply need to adjust the data passed into the error.

## Solution

Moving the default `errData` variable up, and using that in the same manner as the other errors with the generic JSON parse error.

## Testing

New tests were added to check for this new expectation.

`npm run test`