### PR TITLE
fix catching any undefined http errors

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -125,6 +125,8 @@ Resource.prototype = {
                     );
                 }
 
+                const anyError = /(4\d{2}|5\d{2})/;
+
                 if (res.statusCode === 401) {
                     errData.message = "Invalid credentials";
                     err = new Error.ShippoAuthenticationError(errData);
@@ -136,6 +138,9 @@ Resource.prototype = {
                     err = new Error.ShippoAPIError(errData);
                 } else if (res.statusCode === 400) {
                     errData.message = "The data you sent was not accepted as valid";
+                    err = new Error.ShippoAPIError(errData);
+                } else if ((anyError).test(res.statusCode)) {
+                    errData.message = "Something went wrong";
                     err = new Error.ShippoAPIError(errData);
                 }
                 if (err) {


### PR DESCRIPTION
This allows any error response not defined to be caught so its not mistakenly returned as a success response. For example 403 or 500 class errors.